### PR TITLE
Only look for Development.Module python component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ set(VERSION_STRING ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH})
 add_definitions(-DGFAL2_PYTHON_VERSION="${VERSION_STRING}")
 
 # Find build packages
-find_package(Python REQUIRED COMPONENTS Interpreter Development)
+find_package(Python REQUIRED COMPONENTS Interpreter Development.Module REQUIRED)
 find_package(Boost COMPONENTS "python3${Python_VERSION_MINOR}")
 if(NOT Boost_LIBRARIES)
   # Failed to find a specific Python3x version, fallback to Python3


### PR DESCRIPTION
Looking for `Development` includes interpreter embedding, which requires the libpython. 

This creates issues for building wheels in manylinux containers that intentionally do not ship libpython.

For building extension modules, only `Development.Module` is needed.